### PR TITLE
Add Macros

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,44 +1,37 @@
 name: Swift
-
 on: [push]
-
 jobs:
-  build:
-    name: Build
-    strategy:
-      matrix:
-        swift: [6.0.3]
-        os: [ubuntu-20.04, macos-latest]
-    runs-on: ${{ matrix.os }}
+
+  macos:
+    name: macOS
+    runs-on: macos-15
     steps:
-    - name: Install Swift
-      uses: slashmo/install-swift@v0.3.0
-      with:
-        version: ${{ matrix.swift }}
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Swift Version
       run: swift --version
     - name: Build (Debug)
       run: swift build -c debug
     - name: Build (Release)
       run: swift build -c release
-
-  test:
-    name: Test
+    - name: Test (Debug)
+      run: swift test -c debug
+  
+  linux:
+    name: Linux
     strategy:
       matrix:
-        swift: [6.0.3]
-        os: [ubuntu-20.04, macos-latest]
-    runs-on: ${{ matrix.os }}
+        container: ["swift:6.0.3", "swiftlang/swift:nightly"]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}-jammy
     steps:
-    - name: Install Swift
-      uses: slashmo/install-swift@v0.3.0
-      with:
-        version: ${{ matrix.swift }}
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Swift Version
       run: swift --version
+    - name: Build (Debug)
+      run: swift build -c debug
+    - name: Build (Release)
+      run: swift build -c release
     - name: Test (Debug)
-      run: swift test --configuration debug
+      run: swift test -c debug

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:6.0
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "CoreModel",
@@ -23,9 +24,18 @@ let package = Package(
             ]
         )
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/apple/swift-syntax.git",
+            from: "600.0.1"
+        )
+    ],
     targets: [
         .target(
-            name: "CoreModel"
+            name: "CoreModel",
+            dependencies: [
+                "CoreModelMacros"
+            ]
         ),
         .target(
             name: "CoreDataModel",
@@ -36,10 +46,24 @@ let package = Package(
                 .swiftLanguageMode(.v5)
             ]
         ),
+        .macro(
+          name: "CoreModelMacros",
+          dependencies: [
+              .product(
+                  name: "SwiftSyntaxMacros",
+                  package: "swift-syntax"
+              ),
+              .product(
+                  name: "SwiftCompilerPlugin",
+                  package: "swift-syntax"
+              )
+          ]
+        ),
         .testTarget(
             name: "CoreModelTests",
             dependencies: [
                 "CoreModel",
+                "CoreModelMacros",
                 .byName(
                     name: "CoreDataModel",
                     condition: .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])

--- a/Sources/CoreModel/Macros.swift
+++ b/Sources/CoreModel/Macros.swift
@@ -14,7 +14,7 @@ public macro Entity(_ name: String? = nil) = #externalMacro(
 )
 
 @attached(peer)
-public macro Attribute(type: AttributeType? = nil) = #externalMacro(
+public macro Attribute(_ type: AttributeType? = nil) = #externalMacro(
     module: "CoreModelMacros",
     type: "AttributeMacro"
 )

--- a/Sources/CoreModel/Macros.swift
+++ b/Sources/CoreModel/Macros.swift
@@ -1,0 +1,26 @@
+//
+//  Macros.swift
+//  CoreModel
+//
+//  Created by Alsey Coleman Miller on 6/17/25.
+//
+
+
+
+@attached(member, names: named(entityName))
+public macro Entity(_ name: String? = nil) = #externalMacro(
+    module: "CoreModelMacros",
+    type: "EntityMacro"
+)
+
+@attached(peer)
+public macro Attribute(type: AttributeType? = nil) = #externalMacro(
+    module: "CoreModelMacros",
+    type: "AttributeMacro"
+)
+
+@attached(peer)
+public macro Relationship<K: CodingKey>(inverse: CodingKey) = #externalMacro(
+    module: "CoreModelMacros",
+    type: "RelationshipMacro"
+)

--- a/Sources/CoreModel/Macros.swift
+++ b/Sources/CoreModel/Macros.swift
@@ -5,8 +5,6 @@
 //  Created by Alsey Coleman Miller on 6/17/25.
 //
 
-
-
 @attached(member, names: arbitrary)
 public macro Entity(_ name: String? = nil) = #externalMacro(
     module: "CoreModelMacros",
@@ -20,7 +18,7 @@ public macro Attribute(_ type: AttributeType? = nil) = #externalMacro(
 )
 
 @attached(peer)
-public macro Relationship<Root, Value>(inverse: KeyPath<Root, Value>) = #externalMacro(
+public macro Relationship<T: CoreModel.Entity>(destination: T.Type, inverse: T.CodingKeys) = #externalMacro(
     module: "CoreModelMacros",
     type: "RelationshipMacro"
 )

--- a/Sources/CoreModel/Macros.swift
+++ b/Sources/CoreModel/Macros.swift
@@ -7,7 +7,7 @@
 
 
 
-@attached(member, names: named(entityName))
+@attached(member, names: arbitrary)
 public macro Entity(_ name: String? = nil) = #externalMacro(
     module: "CoreModelMacros",
     type: "EntityMacro"
@@ -20,7 +20,7 @@ public macro Attribute(_ type: AttributeType? = nil) = #externalMacro(
 )
 
 @attached(peer)
-public macro Relationship<K: CodingKey>(inverse: CodingKey) = #externalMacro(
+public macro Relationship<Root, Value>(inverse: KeyPath<Root, Value>) = #externalMacro(
     module: "CoreModelMacros",
     type: "RelationshipMacro"
 )

--- a/Sources/CoreModelMacros/Attribute.swift
+++ b/Sources/CoreModelMacros/Attribute.swift
@@ -1,0 +1,23 @@
+//
+//  Attribute.swift
+//  CoreModel
+//
+//  Created by Alsey Coleman Miller on 6/17/25.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AttributeMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+
+        // Tag only, logic handled in EntityMacro
+        return []
+    }
+}

--- a/Sources/CoreModelMacros/Attribute.swift
+++ b/Sources/CoreModelMacros/Attribute.swift
@@ -21,3 +21,22 @@ public struct AttributeMacro: PeerMacro {
         return []
     }
 }
+
+internal func inferAttributeType(from type: String) -> String? {
+    switch type {
+        case "String": return ".string"
+        case "Data": return ".data"
+        case "Bool": return ".bool"
+        case "Int16": return ".int16"
+        case "Int32": return ".int32"
+        case "Int64": return ".int64"
+        case "Int": return ".int64"
+        case "Float": return ".float"
+        case "Double": return ".double"
+        case "Date": return ".date"
+        case "UUID": return ".uuid"
+        case "URL": return ".url"
+        case "Decimal": return ".decimal"
+        default: return nil
+    }
+}

--- a/Sources/CoreModelMacros/Entity.swift
+++ b/Sources/CoreModelMacros/Entity.swift
@@ -1,0 +1,103 @@
+//
+//  Entity.swift
+//  CoreModel
+//
+//  Created by Alsey Coleman Miller on 6/17/25.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// `@Entity` macro
+///
+/// Adds protocol conformance and implementaion for entity name.
+public struct EntityMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+
+        // get type name
+        let typeName: String
+        if let structDecl = declaration.as(StructDeclSyntax.self) {
+            typeName = structDecl.name.text
+        } else if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            typeName = classDecl.name.text
+        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+            typeName = enumDecl.name.text
+        } else {
+            throw MacroError.invalidType
+        }
+        
+        // Extract optional entity name
+        let nameArg = (node.arguments?.firstToken(viewMode: .sourceAccurate) as? LabeledExprListSyntax)?
+            .first?
+            .expression
+            .description
+            .trimmingCharacters(in: .punctuationCharacters)
+        
+        let entityName = nameArg ?? typeName
+
+        let entityNameDecl = """
+        static var entityName: String { "\(entityName)" }
+        """
+
+        // Collect @Attribute properties with metadata
+        var attributeEntries: [String] = []
+/*
+        for member in declaration.memberBlock {
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+                  let binding = varDecl.bindings.first,
+                  let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
+                  let typeSyntax = binding.typeAnnotation?.type,
+                  let attributes = varDecl.attributes else { continue }
+
+            let typeName = typeSyntax.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            let inferredType: String
+
+            if typeName.hasPrefix("Optional") || typeName.hasSuffix("?") {
+                inferredType = ".optional"
+            } else if typeName == "String" {
+                inferredType = ".string"
+            } else if typeName == "Int" || typeName == "Int64" || typeName == "Int32" {
+                inferredType = ".integer"
+            } else if typeName == "Double" || typeName == "Float" {
+                inferredType = ".float"
+            } else if typeName == "Bool" {
+                inferredType = ".boolean"
+            } else if typeName == "Date" {
+                inferredType = ".date"
+            } else {
+                inferredType = ".unsupported(\"\(typeName)\")"
+            }
+
+            for attr in attributes.compactMap({ $0.as(AttributeSyntax.self) }) {
+                if attr.attributeName.description == "Attribute" {
+                    if let argument = attr.argument?.description.trimmingCharacters(in: .whitespacesAndNewlines) {
+                        // Use explicit parameter
+                        attributeEntries.append(".\(identifier): \(argument)")
+                    } else {
+                        // Use inferred type
+                        attributeEntries.append(".\(identifier): AttributeType(\(inferredType))")
+                    }
+                }
+            }
+        }*/
+
+        let attributesDecl = """
+        static var attributes: [CodingKeys: AttributeType] {
+            [\n                \(attributeEntries.joined(separator: ",\n                "))
+            ]
+        }
+        """
+
+        return [
+            DeclSyntax(stringLiteral: entityNameDecl),
+            DeclSyntax(stringLiteral: attributesDecl)
+        ]
+    }
+}
+

--- a/Sources/CoreModelMacros/Entity.swift
+++ b/Sources/CoreModelMacros/Entity.swift
@@ -106,40 +106,22 @@ extension EntityMacro {
 
             let attributes = varDecl.attributes
             
-            let typeName = typeSyntax.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            let rawTypeName = typeSyntax.description.trimmingCharacters(in: .whitespacesAndNewlines)
             
-            let inferredType: String?
-
-            switch typeName {
-            case "String":
-                inferredType = ".string"
-            case "Data":
-                inferredType = ".data"
-            case "Bool":
-                inferredType = ".bool"
-            case "Int16":
-                inferredType = ".int16"
-            case "Int32":
-                inferredType = ".int32"
-            case "Int64":
-                inferredType = ".int64"
-            case "Int":
-                inferredType = ".int64"
-            case "Float":
-                inferredType = ".float"
-            case "Double":
-                inferredType = ".double"
-            case "Date":
-                inferredType = ".date"
-            case "UUID":
-                inferredType = ".uuid"
-            case "URL":
-                inferredType = ".url"
-            case "Decimal":
-                inferredType = ".decimal"
-            default:
-                inferredType = nil
+            // Strip Optional
+            let typeName: String
+            if rawTypeName.hasPrefix("Optional<") {
+                typeName = rawTypeName
+                    .replacingOccurrences(of: "Optional<", with: "")
+                    .dropLast()
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            } else if rawTypeName.hasSuffix("?") {
+                typeName = String(rawTypeName.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                typeName = rawTypeName
             }
+            
+            let inferredType = inferAttributeType(from: typeName)
             
             for attr in attributes.compactMap({ $0.as(AttributeSyntax.self) }) {
                 if attr.attributeName.description == "Attribute" {

--- a/Sources/CoreModelMacros/Entity.swift
+++ b/Sources/CoreModelMacros/Entity.swift
@@ -84,7 +84,7 @@ extension EntityMacro {
             entityName = try typeName(of: node, providingMembersOf: declaration, in: context)
         }
         let entityNameDecl = """
-        static var entityName: String { "\(entityName)" }
+        public static var entityName: String { "\(entityName)" }
         """
         return DeclSyntax(stringLiteral: entityNameDecl)
     }
@@ -159,7 +159,7 @@ extension EntityMacro {
         }
 
         let attributesDecl = """
-        static var attributes: [CodingKeys: AttributeType] {
+        public static var attributes: [CodingKeys: AttributeType] {
             [\n                \(attributeEntries.joined(separator: ",\n                "))
             ]
         }
@@ -235,7 +235,7 @@ extension EntityMacro {
         }
 
         let relationshipsDecl = """
-        static var relationships: [CodingKeys: Relationship] {
+        public static var relationships: [CodingKeys: Relationship] {
             [\n            \(relationshipEntries.joined(separator: ",\n            "))
             ]
         }

--- a/Sources/CoreModelMacros/Entity.swift
+++ b/Sources/CoreModelMacros/Entity.swift
@@ -65,12 +65,11 @@ extension EntityMacro {
         providingMembersOf declaration: some DeclGroupSyntax,
         in context: some MacroExpansionContext
     ) throws -> String? {
-        // Extract optional entity name
-        return (node.arguments?.firstToken(viewMode: .sourceAccurate) as? LabeledExprListSyntax)?
-            .first?
-            .expression
-            .description
-            .trimmingCharacters(in: .punctuationCharacters)
+        guard let arguments = node.arguments?.as(LabeledExprListSyntax.self),
+              let first = arguments.first else {
+            return nil
+        }
+        return first.expression.description.trimmingCharacters(in: .punctuationCharacters)
     }
     
     public static func entityNameDeclarationSyntax(
@@ -97,7 +96,7 @@ extension EntityMacro {
     ) throws -> DeclSyntax {
         // Collect @Attribute properties with metadata
         var attributeEntries: [String] = []
-
+/*
         for member in declaration.memberBlock {
             guard let varDecl = member.decl.as(VariableDeclSyntax.self),
                   let binding = varDecl.bindings.first,
@@ -152,7 +151,7 @@ extension EntityMacro {
                 }
             }
         }
-
+*/
         let attributesDecl = """
         static var attributes: [CodingKeys: AttributeType] {
             [\n                \(attributeEntries.joined(separator: ",\n                "))

--- a/Sources/CoreModelMacros/Entity.swift
+++ b/Sources/CoreModelMacros/Entity.swift
@@ -96,17 +96,19 @@ extension EntityMacro {
     ) throws -> DeclSyntax {
         // Collect @Attribute properties with metadata
         var attributeEntries: [String] = []
-/*
-        for member in declaration.memberBlock {
+        
+        for member in declaration.memberBlock.members {
             guard let varDecl = member.decl.as(VariableDeclSyntax.self),
                   let binding = varDecl.bindings.first,
                   let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text,
-                  let typeSyntax = binding.typeAnnotation?.type,
-                  let attributes = varDecl.attributes else { continue }
+                  let typeSyntax = binding.typeAnnotation?.type
+                  else { continue }
 
+            let attributes = varDecl.attributes
+            
             let typeName = typeSyntax.description.trimmingCharacters(in: .whitespacesAndNewlines)
             
-            let inferredType: String
+            let inferredType: String?
 
             switch typeName {
             case "String":
@@ -122,7 +124,7 @@ extension EntityMacro {
             case "Int64":
                 inferredType = ".int64"
             case "Int":
-                inferredType = ".int64" // Default Int maps to int64
+                inferredType = ".int64"
             case "Float":
                 inferredType = ".float"
             case "Double":
@@ -136,22 +138,26 @@ extension EntityMacro {
             case "Decimal":
                 inferredType = ".decimal"
             default:
-                inferredType = ".string" // fallback, or emit a compiler diagnostic
+                inferredType = nil
             }
-
+            
             for attr in attributes.compactMap({ $0.as(AttributeSyntax.self) }) {
                 if attr.attributeName.description == "Attribute" {
+                    let type: String
                     if let argument = attr.argument?.description.trimmingCharacters(in: .whitespacesAndNewlines) {
                         // Use explicit parameter
-                        attributeEntries.append(".\(identifier): \(argument)")
-                    } else {
+                        type = argument
+                    } else if let inferredType {
                         // Use inferred type
-                        attributeEntries.append(".\(identifier): AttributeType(\(inferredType))")
+                        type = inferredType
+                    } else {
+                        throw MacroError.unknownAttributeType(for: identifier)
                     }
+                    attributeEntries.append(".\(identifier): \(type)")
                 }
             }
         }
-*/
+
         let attributesDecl = """
         static var attributes: [CodingKeys: AttributeType] {
             [\n                \(attributeEntries.joined(separator: ",\n                "))

--- a/Sources/CoreModelMacros/Error.swift
+++ b/Sources/CoreModelMacros/Error.swift
@@ -8,4 +8,5 @@
 enum MacroError: Error {
     
     case invalidType
+    case unknownAttributeType(for: String)
 }

--- a/Sources/CoreModelMacros/Error.swift
+++ b/Sources/CoreModelMacros/Error.swift
@@ -1,0 +1,11 @@
+//
+//  Error.swift
+//  CoreModel
+//
+//  Created by Alsey Coleman Miller on 6/17/25.
+//
+
+enum MacroError: Error {
+    
+    case invalidType
+}

--- a/Sources/CoreModelMacros/Error.swift
+++ b/Sources/CoreModelMacros/Error.swift
@@ -9,4 +9,5 @@ enum MacroError: Error {
     
     case invalidType
     case unknownAttributeType(for: String)
+    case unknownInverseRelationship(for: String)
 }

--- a/Sources/CoreModelMacros/Macros.swift
+++ b/Sources/CoreModelMacros/Macros.swift
@@ -1,0 +1,20 @@
+//
+//  Macros.swift
+//  CoreModel
+//
+//  Created by Alsey Coleman Miller on 6/17/25.
+//
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct Plugins: CompilerPlugin {
+    
+    let providingMacros: [Macro.Type] = [
+        EntityMacro.self,
+        RelationshipMacro.self,
+        AttributeMacro.self
+    ]
+}

--- a/Sources/CoreModelMacros/Relationship.swift
+++ b/Sources/CoreModelMacros/Relationship.swift
@@ -1,0 +1,23 @@
+//
+//  Relationship.swift
+//  CoreModel
+//
+//  Created by Alsey Coleman Miller on 6/17/25.
+//
+
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct RelationshipMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+
+        // Tag only, logic handled in EntityMacro
+        return []
+    }
+}

--- a/Tests/CoreModelTests/CoreDataTests.swift
+++ b/Tests/CoreModelTests/CoreDataTests.swift
@@ -9,14 +9,15 @@
 
 import Foundation
 import CoreData
-import XCTest
+import Testing
 @testable import CoreModel
 @testable import CoreDataModel
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
-final class CoreDataTests: XCTestCase {
+@Suite
+struct CoreDataTests {
     
-    func testCoreData() async throws {
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @Test func coreData() async throws {
         
         let model = Model(
             entities:
@@ -53,10 +54,10 @@ final class CoreDataTests: XCTestCase {
         var event1Data = try event1.encode(log: { print("Encoder:", $0) })
         try await store.insert(event1Data)
         person1 = try await store.fetch(Person.self, for: person1.id)!
-        XCTAssertEqual(person1.events, [event1.id])
+        #expect(person1.events == [event1.id])
         event1Data = try await store.fetch(Event.entityName, for: ObjectID(event1.id))!
         event1 = try .init(from: event1Data, log: { print("Decoder:", $0) })
-        XCTAssertEqual(event1.people, [person1.id])
+        #expect(event1.people == [person1.id])
         
         var campground = Campground(
             name: "Fair Play RV Park",
@@ -81,21 +82,21 @@ final class CoreDataTests: XCTestCase {
         var campgroundData = try campground.encode(log: { print("Encoder:", $0) })
         try await store.insert(campgroundData)
         let rentalUnitData = try rentalUnit.encode(log: { print("Encoder:", $0) })
-        XCTAssertEqual(rentalUnitData.relationships[PropertyKey(Campground.RentalUnit.CodingKeys.campground)], .toOne(ObjectID(campground.id)))
+        #expect(rentalUnitData.relationships[PropertyKey(Campground.RentalUnit.CodingKeys.campground)] == .toOne(ObjectID(campground.id)))
         try await store.insert(rentalUnitData)
         campgroundData = try await store.fetch(Campground.entityName, for: ObjectID(campground.id))!
         campground = try .init(from: campgroundData, log: { print("Decoder:", $0) })
-        XCTAssertEqual(campground.units, [rentalUnit.id])
-        XCTAssertEqual(campgroundData.relationships[PropertyKey(Campground.CodingKeys.units)], .toMany([ObjectID(rentalUnit.id)]))
+        #expect(campground.units == [rentalUnit.id])
+        #expect(campgroundData.relationships[PropertyKey(Campground.CodingKeys.units)] == .toMany([ObjectID(rentalUnit.id)]))
         let fetchedRentalUnit = try await store.fetch(Campground.RentalUnit.self, for: rentalUnit.id)
-        XCTAssertEqual(fetchedRentalUnit, rentalUnit)
+        #expect(fetchedRentalUnit == rentalUnit)
         
         let rentalUnitFetchRequest = FetchRequest(
             entity: Campground.RentalUnit.entityName,
             predicate: Campground.RentalUnit.CodingKeys.campground.stringValue.compare(.equalTo, .relationship(.toOne(ObjectID(campground.id))))
         )
         let rentalUnitIDs = try await store.fetchID(rentalUnitFetchRequest)
-        XCTAssertEqual(rentalUnitIDs, campground.units.map { ObjectID($0) })
+        #expect(rentalUnitIDs == campground.units.map { ObjectID($0) })
     }
 }
 

--- a/Tests/CoreModelTests/CoreModelTests.swift
+++ b/Tests/CoreModelTests/CoreModelTests.swift
@@ -6,16 +6,16 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import CoreModel
 
-final class CoreModelTests: XCTestCase {
+@Suite struct CoreModelTests {
     
-    func testEntityName() {
+    @Test func entityName() {
         
-        XCTAssertEqual(Person.entityName, "Person")
-        XCTAssertEqual(Event.entityName, "Event")
-        XCTAssertEqual(Campground.entityName, "Campground")
-        XCTAssertEqual(Campground.RentalUnit.entityName, "RentalUnit")
+        #expect(Person.entityName == "Person")
+        #expect(Event.entityName == "Event")
+        #expect(Campground.entityName == "Campground")
+        #expect(Campground.RentalUnit.entityName == "RentalUnit")
     }
 }

--- a/Tests/CoreModelTests/CoreModelTests.swift
+++ b/Tests/CoreModelTests/CoreModelTests.swift
@@ -18,4 +18,139 @@ import Testing
         #expect(Campground.entityName == "Campground")
         #expect(Campground.RentalUnit.entityName == "RentalUnit")
     }
+    
+    @Test func testPersonEntity() {
+        validateEntityConformance(Person.self)
+    }
+    
+    @Test func testEventEntity() {
+        validateEntityConformance(Event.self)
+    }
+    
+    @Test func testCampgroundEntity() {
+        validateEntityConformance(Campground.self)
+    }
+    
+    @Test func testRentalUnitEntity() {
+        validateEntityConformance(Campground.RentalUnit.self)
+    }
 }
+
+protocol EntityTestInfo {
+    static var expectedEntityName: String { get }
+    
+    /// Key is attribute CodingKey string, Value is expected AttributeType
+    static var expectedAttributes: [String: AttributeType] { get }
+    
+    /// Key is relationship CodingKey string, value is tuple of
+    /// (relationship type, destination entity name, optional inverse relationship key string)
+    static var expectedRelationships: [String: (type: RelationshipType, destinationEntity: String, inverseRelationshipKey: String?)] { get }
+}
+
+// MARK: - Generic Validator
+
+extension CoreModelTests {
+    
+    func validateEntityConformance<E: Entity & EntityTestInfo>(_ entityType: E.Type) {
+        
+        #expect(E.entityName.description == E.expectedEntityName, "entityName mismatch for \(E.self)")
+        
+        // Validate attributes
+        for (expectedKey, expectedType) in E.expectedAttributes {
+            guard let actualType = E.attributes.first(where: { "\($0.key.stringValue)" == expectedKey })?.value else {
+                Issue.record("Missing attribute '\(expectedKey)' in \(E.self)")
+                return
+            }
+            #expect(actualType == expectedType, "Attribute '\(expectedKey)' type mismatch for \(E.self)")
+        }
+        
+        // Validate relationships
+        for (expectedKey, expectedRel) in E.expectedRelationships {
+            guard let actualRel = E.relationships.first(where: { "\($0.key.stringValue)" == expectedKey })?.value else {
+                Issue.record("Missing relationship '\(expectedKey)' in \(E.self)")
+                return
+            }
+            #expect(actualRel.type == expectedRel.type, "Relationship '\(expectedKey)' type mismatch for \(E.self)")
+            #expect(actualRel.destinationEntity.rawValue == expectedRel.destinationEntity, "Relationship '\(expectedKey)' destinationEntity mismatch for \(E.self)")
+            if let expectedInverse = expectedRel.inverseRelationshipKey {
+                #expect("\(actualRel.inverseRelationship)" == expectedInverse, "Relationship '\(expectedKey)' inverseRelationship mismatch for \(E.self)")
+            }
+        }
+    }
+}
+
+// MARK: - EntityTestInfo Implementations
+
+extension Person: EntityTestInfo {
+    static var expectedEntityName: String { "Person" }
+    static var expectedAttributes: [String : AttributeType] {
+        [
+            "name": .string,
+            "created": .date,
+            "age": .int16
+        ]
+    }
+    static var expectedRelationships: [String : (type: RelationshipType, destinationEntity: String, inverseRelationshipKey: String?)] {
+        [
+            "events": (.toMany, "Event", "people")
+        ]
+    }
+}
+
+extension Event: EntityTestInfo {
+    static var expectedEntityName: String { "Event" }
+    static var expectedAttributes: [String : AttributeType] {
+        [
+            "name": .string,
+            "date": .date
+        ]
+    }
+    static var expectedRelationships: [String : (type: RelationshipType, destinationEntity: String, inverseRelationshipKey: String?)] {
+        [
+            "people": (.toMany, Person.entityName, "events")
+        ]
+    }
+}
+
+extension Campground: EntityTestInfo {
+    static var expectedEntityName: String { "Campground" }
+    static var expectedAttributes: [String : AttributeType] {
+        [
+            "name": .string,
+            "created": .date,
+            "updated": .date,
+            "address": .string,
+            "location": .string,
+            "amenities": .string,
+            "phoneNumber": .string,
+            "descriptionText": .string,
+            "timeZone": .int32,
+            "notes": .string,
+            "directions": .string,
+            "officeHours": .string
+        ]
+    }
+    static var expectedRelationships: [String : (type: RelationshipType, destinationEntity: String, inverseRelationshipKey: String?)] {
+        [
+            "units": (.toMany, "RentalUnit", "campground")
+        ]
+    }
+}
+
+extension Campground.RentalUnit: EntityTestInfo {
+    static var expectedEntityName: String { "RentalUnit" }
+    static var expectedAttributes: [String : AttributeType] {
+        [
+            "name": .string,
+            "notes": .string,
+            "amenities": .string,
+            "checkout": .string
+        ]
+    }
+    static var expectedRelationships: [String : (type: RelationshipType, destinationEntity: String, inverseRelationshipKey: String?)] {
+        [
+            "campground": (.toOne, "Campground", "units")
+        ]
+    }
+}
+

--- a/Tests/CoreModelTests/NSPredicateTests.swift
+++ b/Tests/CoreModelTests/NSPredicateTests.swift
@@ -8,23 +8,20 @@
 
 #if canImport(Darwin)
 import Foundation
-import XCTest
+import Testing
 @testable import CoreModel
 @testable import CoreDataModel
 
-final class NSPredicateTests: XCTestCase {
+@Suite struct NSPredicateTests {
     
-    func testDescription() {
+    @Test func description() {
         
-        XCTAssertEqual((.keyPath("name") == .attribute(.string("Coleman"))).description,
-                       NSPredicate(format: "name == \"Coleman\"").description)
-        XCTAssertEqual(((.keyPath("name") != .attribute(.null)) as FetchRequest.Predicate).description,
-                       NSPredicate(format: "name != nil").description)
-        XCTAssertEqual((!(.keyPath("name") == .attribute(.null))).description,
-                       NSPredicate(format: "NOT name == nil").description)
+        #expect((.keyPath("name") == .attribute(.string("Coleman"))).description == NSPredicate(format: "name == \"Coleman\"").description)
+        #expect(((.keyPath("name") != .attribute(.null)) as FetchRequest.Predicate).description == NSPredicate(format: "name != nil").description)
+        #expect((!(.keyPath("name") == .attribute(.null))).description == NSPredicate(format: "NOT name == nil").description)
     }
     
-    func testComparison() {
+    @Test func comparison() {
         
         let predicate: FetchRequest.Predicate = #keyPath(PersonObject.id) > Int64(0)
             && (#keyPath(PersonObject.name)).compare(.notEqualTo, .attribute(.null))
@@ -38,11 +35,11 @@ final class NSPredicateTests: XCTestCase {
         print(predicate)
         print(converted)
         
-        XCTAssertEqual(predicate.description, converted.description)
-        XCTAssert(converted.evaluate(with: PersonObject(id: 1, name: "Coléman")))
+        #expect(predicate.description == converted.description)
+        #expect(converted.evaluate(with: PersonObject(id: 1, name: "Coléman")))
     }
     
-    func testPredicateFilter() {
+    @Test func predicateFilter() {
         
         let events = [
             EventObject(
@@ -78,10 +75,10 @@ final class NSPredicateTests: XCTestCase {
         print(predicate)
         print(nsPredicate)
         
-        XCTAssertEqual((events as NSArray).filtered(using: nsPredicate).count, events.count)
+        #expect((events as NSArray).filtered(using: nsPredicate).count == events.count)
     }
     
-    func testPredicateAggregate() {
+    @Test func predicateAggregate() {
         
         let events = [
             EventObject(
@@ -132,10 +129,10 @@ final class NSPredicateTests: XCTestCase {
         print(predicate)
         print(nsPredicate)
         
-        XCTAssertEqual((events as NSArray).filtered(using: nsPredicate).count, events.count)
+        #expect((events as NSArray).filtered(using: nsPredicate).count == events.count)
     }
     
-    func testPredicateContains() throws {
+    @Test func predicateContains() throws {
         
         let attributes = AttributesObject()
         attributes.data = Data()
@@ -152,7 +149,7 @@ final class NSPredicateTests: XCTestCase {
         print(predicate)
         print(nsPredicate)
         
-        XCTAssertEqual(predicate.description, nsPredicate.description, "Invalid description")
+        #expect(predicate.description == nsPredicate.description, "Invalid description")
         nsPredicate.evaluate(with: attributes)
     }
 }

--- a/Tests/CoreModelTests/PredicateTests.swift
+++ b/Tests/CoreModelTests/PredicateTests.swift
@@ -6,30 +6,31 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import CoreModel
 
-final class PredicateTests: XCTestCase {
+@Suite
+struct PredicateTests {
     
-    func testDescription() {
+    @Test func description() {
         
-        XCTAssertEqual((.keyPath("name") == .attribute(.string("Coleman"))).description, "name == \"Coleman\"")
-        XCTAssertEqual(((.keyPath("name") != .attribute(.null)) as FetchRequest.Predicate).description, "name != nil")
-        XCTAssertEqual((!(.keyPath("name") == .attribute(.null))).description, "NOT name == nil")
-        XCTAssertEqual(("isValid" == false).description, "isValid == false")
+        #expect((.keyPath("name") == .attribute(.string("Coleman"))).description == "name == \"Coleman\"")
+        #expect(((.keyPath("name") != .attribute(.null)) as FetchRequest.Predicate).description == "name != nil")
+        #expect((!(.keyPath("name") == .attribute(.null))).description == "NOT name == nil")
+        #expect(("isValid" == false).description == "isValid == false")
     }
     
-    func testPredicate1() {
+    @Test func predicate1() {
         
         let predicate: FetchRequest.Predicate = "id" > Int64(0)
             && "id" != Int64(99)
             && "name".compare(.beginsWith, .attribute(.string("C")))
             && "name".compare(.contains, [.diacriticInsensitive, .caseInsensitive], .attribute(.string("COLE")))
         
-        XCTAssertEqual(predicate.description, #"((id > 0 AND id != 99) AND name BEGINSWITH "C") AND name CONTAINS[cd] "COLE""#)
+        #expect(predicate.description == #"((id > 0 AND id != 99) AND name BEGINSWITH "C") AND name CONTAINS[cd] "COLE""#)
     }
     
-    func testPredicate2() {
+    @Test func predicate2() {
         
         let events = [
             Event(
@@ -76,7 +77,7 @@ final class PredicateTests: XCTestCase {
             ]
         
         #if !os(WASI)
-        XCTAssertEqual(predicate.description, #"name MATCHES[c] "event \d" AND start < 4001-01-01 00:00:00 +0000 AND speakers.@count > 0"#)
+        #expect(predicate.description == #"name MATCHES[c] "event \d" AND start < 4001-01-01 00:00:00 +0000 AND speakers.@count > 0"#)
         #endif
     }
 }

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -22,7 +22,7 @@ struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
     @Attribute(.int16)
     var age: UInt
     
-    @Relationship(inverse: \Event.people)
+    @Relationship(destination: Event.self, inverse: .people)
     var events: [Event.ID]
     
     init(id: UUID = UUID(), name: String, created: Date = Date(), age: UInt, events: [Event.ID] = []) {
@@ -71,19 +71,19 @@ extension Person {
     }
 }
 
-struct Event: Equatable, Hashable, Codable, Identifiable {
+@Entity
+struct Event: Equatable, Hashable, Codable, Identifiable, Entity {
     
     let id: UUID
     
+    @Attribute
     var name: String
     
+    @Attribute
     var date: Date
     
+    @Relationship(destination: Person.self, inverse: .events)
     var people: [Person.ID]
-    
-    //var speaker: Person.ID?
-    
-    //var notes: String?
     
     init(id: UUID = UUID(), name: String, date: Date, people: [Person.ID] = []) {
         self.id = id
@@ -97,26 +97,6 @@ struct Event: Equatable, Hashable, Codable, Identifiable {
         case name
         case date
         case people
-    }
-}
-
-extension Event: Entity {
-        
-    static var attributes: [CodingKeys: AttributeType] {
-        [
-            .name: .string,
-            .date: .date
-        ]
-    }
-    
-    static var relationships: [CodingKeys: Relationship] {
-        [
-            .people: .init(
-                id: PropertyKey(CodingKeys.people),
-                type: .toMany,
-                destinationEntity: Person.entityName,
-                inverseRelationship: PropertyKey(Person.CodingKeys.events))
-        ]
     }
 }
 

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -101,36 +101,50 @@ struct Event: Equatable, Hashable, Codable, Identifiable, Entity {
 }
 
 /// Campground Location
-public struct Campground: Equatable, Hashable, Codable, Identifiable {
+@Entity("Campground")
+public struct Campground: Equatable, Hashable, Codable, Identifiable, Entity {
     
     public let id: UUID
     
+    @Attribute
     public let created: Date
     
+    @Attribute
     public let updated: Date
     
+    @Attribute
     public var name: String
     
+    @Attribute
     public var address: String
     
+    @Attribute(.string)
     public var location: LocationCoordinates
     
+    @Attribute(.string)
     public var amenities: [Amenity]
     
+    @Attribute(.string)
     public var phoneNumber: String?
     
+    @Attribute
     public var descriptionText: String
     
     /// The number of seconds from GMT.
+    @Attribute(.int32)
     public var timeZone: Int
     
+    @Attribute(.string)
     public var notes: String?
     
+    @Attribute(.string)
     public var directions: String?
     
-    public var units: [RentalUnit.ID]
-    
+    @Attribute(.string)
     public var officeHours: Schedule
+    
+    @Relationship(destination: RentalUnit.self, inverse: .campground)
+    public var units: [RentalUnit.ID]
     
     public init(
         id: UUID = UUID(),
@@ -179,37 +193,6 @@ public struct Campground: Equatable, Hashable, Codable, Identifiable {
         case directions
         case units
         case officeHours
-    }
-}
-
-extension Campground: Entity {
-    
-    public static var attributes: [CodingKeys: AttributeType] {
-        [
-            .name : .string,
-            .created : .date,
-            .updated : .date,
-            .address : .string,
-            .location: .string,
-            .amenities: .string,
-            .phoneNumber: .string,
-            .descriptionText: .string,
-            .timeZone: .int32,
-            .notes: .string,
-            .directions: .string,
-            .officeHours: .string
-        ]
-    }
-    
-    public static var relationships: [CodingKeys: Relationship] {
-        [
-            .units : Relationship(
-                id: PropertyKey(CodingKeys.units),
-                type: .toMany,
-                destinationEntity: RentalUnit.entityName,
-                inverseRelationship: PropertyKey(RentalUnit.CodingKeys.campground)
-            )
-        ]
     }
 }
 

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -8,14 +8,19 @@
 import Foundation
 import CoreModel
 
-struct Person: Equatable, Hashable, Codable, Identifiable {
+@Entity
+struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
     
+    @Attribute
     let id: UUID
     
+    @Attribute
     var name: String
     
+    @Attribute
     var created: Date
     
+    @Attribute
     var age: UInt
     
     var events: [Event.ID]
@@ -35,17 +40,10 @@ struct Person: Equatable, Hashable, Codable, Identifiable {
         case age
         case events
     }
+    
 }
 
-extension Person: Entity {
-        
-    static var attributes: [CodingKeys: AttributeType] {
-        [
-            .name: .string,
-            .created: .date,
-            .age: .int16
-        ]
-    }
+extension Person {
     
     static var relationships: [CodingKeys: Relationship] {
         [

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -45,18 +45,6 @@ struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
 
 extension Person {
     
-    static var relationships: [CodingKeys: Relationship] {
-        [
-            .events: Relationship(
-                id: .events,
-                entity: Person.self,
-                destination: Event.self,
-                type: .toMany,
-                inverseRelationship: .people
-            )
-        ]
-    }
-    
     init(from container: ModelData) throws {
         guard container.entity == Self.entityName else {
             throw DecodingError.typeMismatch(Self.self, DecodingError.Context(codingPath: [], debugDescription: "Cannot decode \(String(describing: Self.self)) from \(container.entity)"))

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -124,7 +124,7 @@ public struct Campground: Equatable, Hashable, Codable, Identifiable, Entity {
     @Attribute(.string)
     public var amenities: [Amenity]
     
-    @Attribute(.string)
+    @Attribute
     public var phoneNumber: String?
     
     @Attribute
@@ -134,10 +134,10 @@ public struct Campground: Equatable, Hashable, Codable, Identifiable, Entity {
     @Attribute(.int32)
     public var timeZone: Int
     
-    @Attribute(.string)
+    @Attribute
     public var notes: String?
     
-    @Attribute(.string)
+    @Attribute
     public var directions: String?
     
     @Attribute(.string)
@@ -348,7 +348,7 @@ public extension Campground {
         @Attribute
         public var name: String
         
-        @Attribute(.string)
+        @Attribute
         public var notes: String?
         
         @Attribute(.string)

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -23,6 +23,7 @@ struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
     @Attribute(.int16)
     var age: UInt
     
+    @Relationship(inverse: \Event.people)
     var events: [Event.ID]
     
     init(id: UUID = UUID(), name: String, created: Date = Date(), age: UInt, events: [Event.ID] = []) {
@@ -40,7 +41,6 @@ struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
         case age
         case events
     }
-    
 }
 
 extension Person {

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -11,7 +11,6 @@ import CoreModel
 @Entity
 struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
     
-    @Attribute
     let id: UUID
     
     @Attribute

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -337,18 +337,24 @@ extension Campground.Schedule: AttributeDecodable {
 public extension Campground {
     
     /// Campground Rental Unit
-    struct RentalUnit: Equatable, Hashable, Codable, Identifiable {
+    @Entity
+    struct RentalUnit: Equatable, Hashable, Codable, Identifiable, Entity {
         
         public let id: UUID
         
+        @Relationship(destination: Campground.self, inverse: .units)
         public let campground: Campground.ID
         
+        @Attribute
         public var name: String
         
+        @Attribute(.string)
         public var notes: String?
         
+        @Attribute(.string)
         public var amenities: [Amenity]
         
+        @Attribute(.string)
         public var checkout: Schedule
         
         public init(
@@ -376,28 +382,5 @@ public extension Campground {
             case amenities
             case checkout
         }
-    }
-}
-
-extension Campground.RentalUnit: Entity {
-        
-    public static var attributes: [CodingKeys: AttributeType] {
-        [
-            .name : .string,
-            .notes : .string,
-            .amenities : .string,
-            .checkout : .string
-        ]
-    }
-    
-    public static var relationships: [CodingKeys: Relationship] {
-        [
-            .campground : Relationship(
-                id: PropertyKey(CodingKeys.campground),
-                type: .toOne,
-                destinationEntity: Campground.entityName,
-                inverseRelationship: PropertyKey(Campground.CodingKeys.units)
-            )
-        ]
     }
 }

--- a/Tests/CoreModelTests/TestModel.swift
+++ b/Tests/CoreModelTests/TestModel.swift
@@ -20,7 +20,7 @@ struct Person: Equatable, Hashable, Codable, Identifiable, Entity {
     @Attribute
     var created: Date
     
-    @Attribute
+    @Attribute(.int16)
     var age: UInt
     
     var events: [Event.ID]


### PR DESCRIPTION
Add `@Entity`, `@Attribute` and `@Relationship` macros for boilerplate code generation and improved type safety.